### PR TITLE
Fix docstring typo

### DIFF
--- a/tetris_env.py
+++ b/tetris_env.py
@@ -353,7 +353,7 @@ class TetrisEnv(TetrisCore, gym.Env):
     # ── pygame helpers ──
     def _setup_pygame(self):
         """
-        Initialise Pygame and open a window large enough for:
+        Initialize Pygame and open a window large enough for:
         • 120-px HOLD box  (5×24)
         • 20-px gutter
         • 240-px board     (10×24)


### PR DESCRIPTION
## Summary
- correct spelling in `_setup_pygame` docstring

## Testing
- `python3 -m py_compile tetris_env.py`

------
https://chatgpt.com/codex/tasks/task_e_68427b1b69d88321aa4b45b84a95d434