### PR TITLE
Fix rgb_array render and add regression test

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import numpy as np
+
+# Ensure the repository root is on the import path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from tetris_env import TetrisEnv
+
+def test_render_rgb_array_shape():
+    env = TetrisEnv()
+    env.reset()
+    frame = env.render("rgb_array")
+    assert isinstance(frame, np.ndarray)
+    assert frame.shape == (240, 480, 3)
+    assert frame.dtype == np.uint8
+    env.close()

--- a/tetris_env.py
+++ b/tetris_env.py
@@ -285,6 +285,9 @@ class TetrisEnv(TetrisCore, gym.Env):
 
     def __init__(self, seed: int | None = None):
         TetrisCore.__init__(self, seed)
+        # Default cell size used for both pygame and rgb_array rendering
+        # so that _array_frame can be called without initialising a window.
+        self.CELL = 24
         self.action_space = gym.spaces.Discrete(len(self.ACTIONS))
         self.observation_space = gym.spaces.Dict({
             "board":   gym.spaces.Box(0, 7, (20, 10), np.float32),


### PR DESCRIPTION
## Summary
- add missing regression test ensuring `rgb_array` render returns frame
- initialise `self.CELL` in `TetrisEnv.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427b4ac0f08321976dfbf78d8a5d0b