### PR TITLE
Add packaging and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Tetris Trainer
+
+This repository provides a small gym compatible Tetris environment used for reinforcement learning experiments.
+
+## Installation
+
+Install the package in editable mode so the `tetris_env` module can be imported by tests and scripts.
+
+```bash
+pip install -e .
+```
+
+After installation you can run the examples in this repository or your own code that imports `tetris_env`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tetris-env"
+version = "0.1.0"
+description = "Gym compatible Tetris environment"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[tool.setuptools]
+py-modules = ["tetris_env"]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,7 @@
+from tetris_env import TetrisEnv
+
+
+def test_reset():
+    env = TetrisEnv()
+    obs, _ = env.reset()
+    assert "board" in obs


### PR DESCRIPTION
## Summary
- package `tetris_env` so it can be installed in editable mode
- add simple test that imports the module
- document installing the project in editable mode

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842868a8a8c8321ba3e2c99db88f67d