### PR TITLE
Add CLI menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,22 @@ After installation you can run the example scripts in this repository or your ow
 ```bash
 pytest
 ```
+
+## Command Line Interface
+
+A simple menu-driven interface is provided in `cli_menu.py` to make common
+actions easy for beginners. Run the script and pick an option:
+
+```bash
+python cli_menu.py
+```
+
+The menu lets you:
+
+1. Play Tetris manually using the `play.py` demo.
+2. Start training from scratch via `train_offline.py`.
+3. Resume training from a saved checkpoint with `resume_training.py`.
+4. Exit the program.
+
+Each option launches the corresponding script so you do not need to
+remember individual commands.

--- a/cli_menu.py
+++ b/cli_menu.py
@@ -1,0 +1,35 @@
+import sys
+import subprocess
+import textwrap
+
+MENU = textwrap.dedent(
+    """
+    Tetris Trainer CLI
+    ==================
+    1. Play manually
+    2. Train new model (fresh run)
+    3. Resume training (continue)
+    4. Exit
+    """
+)
+
+
+def main():
+    while True:
+        print(MENU)
+        choice = input("Select an option: ").strip()
+        if choice == "1":
+            subprocess.run([sys.executable, "play.py"], check=True)
+        elif choice == "2":
+            subprocess.run([sys.executable, "train_offline.py"], check=True)
+        elif choice == "3":
+            subprocess.run([sys.executable, "resume_training.py"], check=True)
+        elif choice == "4":
+            print("Goodbye!")
+            break
+        else:
+            print("Invalid choice. Please try again.\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide a menu interface in `cli_menu.py`
- document new command line interface in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842aa20e0b48321adfbfce3a905bca2