### PR TITLE
Add configurable step count for training scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ The menu lets you:
 Each option launches the corresponding script so you do not need to
 remember individual commands.
 
-When resuming training, the script now asks which existing checkpoint to
-load and automatically increments the log folder (``logs/run_02``,
-``logs/run_03`` …) so your progress is clearly separated.
+When choosing options 2 or 3 you will be prompted for how many
+environment steps to run. Press <kbd>Enter</kbd> to keep the default
+10,000,000. When resuming training, the script also asks which existing
+checkpoint to load and automatically increments the log folder
+(``logs/run_02``, ``logs/run_03`` …) so your progress is clearly
+separated.

--- a/cli_menu.py
+++ b/cli_menu.py
@@ -21,9 +21,17 @@ def main():
         if choice == "1":
             subprocess.run([sys.executable, "play.py"], check=True)
         elif choice == "2":
-            subprocess.run([sys.executable, "train_offline.py"], check=True)
+            steps = input("Train for how many steps? [10_000_000]: ").strip()
+            cmd = [sys.executable, "train_offline.py"]
+            if steps:
+                cmd += ["--steps", steps]
+            subprocess.run(cmd, check=True)
         elif choice == "3":
-            subprocess.run([sys.executable, "resume_training.py"], check=True)
+            steps = input("Additional steps to train? [10_000_000]: ").strip()
+            cmd = [sys.executable, "resume_training.py"]
+            if steps:
+                cmd += ["--steps", steps]
+            subprocess.run(cmd, check=True)
         elif choice == "4":
             print("Goodbye!")
             break

--- a/resume_training.py
+++ b/resume_training.py
@@ -68,6 +68,12 @@ def main() -> None:
         "--checkpoint",
         help="Checkpoint file to load (default: choose interactively)",
     )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=10_000_000,
+        help="Additional timesteps to train (default: 10_000_000)",
+    )
     args = parser.parse_args()
 
     # ── 1. Build training and eval envs ─────────────────────
@@ -99,9 +105,9 @@ def main() -> None:
         render=False,
     )
 
-    # ── 5. Resume training for another 10M steps ────────────
+    # ── 5. Resume training ─────────────────────────────────
     model.learn(
-        total_timesteps=10_000_000,
+        total_timesteps=args.steps,
         callback=callback,
         reset_num_timesteps=False,
         log_interval=1,


### PR DESCRIPTION
## Summary
- allow specifying training steps in `train_offline.py` and `resume_training.py`
- prompt for number of steps from the CLI menu
- document the new prompts in the README

## Testing
- `pip install -e .`
- `pip install numpy gymnasium gym pygame`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432653c7f88321a9d9b666affa00f7