### PR TITLE
Fix overlay to use renderer window

### DIFF
--- a/live_view.py
+++ b/live_view.py
@@ -15,11 +15,26 @@ Key points:
 
 import time
 import hashlib
-import pygame
 import sys
 from pathlib import Path
-from stable_baselines3 import PPO
-from tetris_env import TetrisEnv
+
+try:  # Ensure pygame is available
+    import pygame
+except ModuleNotFoundError as e:  # pragma: no cover - for runtime diagnostics
+    print("Error: pygame is not installed. Run 'pip install -r requirements.txt' first.")
+    raise SystemExit(1) from e
+
+try:  # Ensure stable_baselines3 is installed
+    from stable_baselines3 import PPO
+except ModuleNotFoundError as e:  # pragma: no cover - for runtime diagnostics
+    print("Error: stable-baselines3 is not installed. Run 'pip install -r requirements.txt' first.")
+    raise SystemExit(1) from e
+
+try:  # Ensure editable install of this repo
+    from tetris_env import TetrisEnv
+except ModuleNotFoundError as e:  # pragma: no cover - for runtime diagnostics
+    print("Error: could not import tetris_env. Did you run 'pip install -e .'?")
+    raise SystemExit(1) from e
 
 BEST_MODEL = Path("checkpoints/best_model.zip")
 last_hash  = None       # MD5 of the last‐loaded checkpoint
@@ -46,11 +61,13 @@ def overlay(text: str):
     """
     Draw a translucent overlay with `text` centered in the window.
     """
-    surf = pygame.Surface(env.window.get_size(), pygame.SRCALPHA)
-    surf.fill((0, 0, 0, 180))  # semi‐transparent black
+    if env.renderer is None or env.renderer.window is None:
+        return
+    surf = pygame.Surface(env.renderer.window.get_size(), pygame.SRCALPHA)
+    surf.fill((0, 0, 0, 180))  # semi-transparent black
     txt  = FONT.render(text, True, (255, 255, 255))
     surf.blit(txt, txt.get_rect(center=surf.get_rect().center))
-    env.window.blit(surf, (0, 0))
+    env.renderer.window.blit(surf, (0, 0))
     pygame.display.flip()
 
 # ── Main loop ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- use `env.renderer.window` in `live_view` overlay to avoid AttributeError

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a647b25c8321a82ba441bb52ae5c