### PR TITLE
Fix single-env playback model loading

### DIFF
--- a/live_view.py
+++ b/live_view.py
@@ -87,7 +87,11 @@ def _load_model_async():
         # which is safe, but calling env.reset() inside this background thread
         # can freeze Pygame.  By loading without ``env`` and assigning it on
         # the main thread, we avoid any Pygame calls outside the main loop.
-        loaded_model = PPO.load(BEST_MODEL, device=device)
+        loaded_model = PPO.load(
+            BEST_MODEL,
+            device=device,
+            custom_objects={"n_envs": 1},  # allow attaching single-env later
+        )
     except Exception as e:
         load_exception = e
 


### PR DESCRIPTION
## Summary
- avoid set_env assertion by forcing n_envs=1 when loading PPO checkpoint in `live_view.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c0f4c6708321b1f8bd67cd472bf3